### PR TITLE
bintray-add-package.py: handle comma separated license list

### DIFF
--- a/scripts/bintray-add-package.py
+++ b/scripts/bintray-add-package.py
@@ -67,7 +67,7 @@ class PackageMetadata():
         with open(build_script_path, "r") as build_script:
             for line in build_script:
                 if line.startswith("TERMUX_PKG_LICENSE"):
-                    self.licenses = self.get_value(line, "TERMUX_PKG_LICENSE")
+                    self.licenses = self.get_value(line, "TERMUX_PKG_LICENSE").split(",")
 
                 if line.startswith("TERMUX_PKG_DESCRIPTION"):
                     self.desc = self.get_value(line, "TERMUX_PKG_DESCRIPTION")
@@ -103,7 +103,7 @@ class PackageMetadata():
         for char in "\"'\n":
             value = value.replace(char, '')
 
-        return value.split(",")
+        return value
 
     def dump(self):
         return self.__dict__

--- a/scripts/bintray-add-package.py
+++ b/scripts/bintray-add-package.py
@@ -67,7 +67,7 @@ class PackageMetadata():
         with open(build_script_path, "r") as build_script:
             for line in build_script:
                 if line.startswith("TERMUX_PKG_LICENSE"):
-                    self.licenses = [self.get_value(line, "TERMUX_PKG_LICENSE")]
+                    self.licenses = self.get_value(line, "TERMUX_PKG_LICENSE")
 
                 if line.startswith("TERMUX_PKG_DESCRIPTION"):
                     self.desc = self.get_value(line, "TERMUX_PKG_DESCRIPTION")
@@ -103,7 +103,7 @@ class PackageMetadata():
         for char in "\"'\n":
             value = value.replace(char, '')
 
-        return value
+        return value.split(",")
 
     def dump(self):
         return self.__dict__


### PR DESCRIPTION
`.split(",")` will give a list even if TERMUX_PKG_LICENSE doesn't contain a "," so this should work