### PR TITLE
[WIP] add package xsel

### DIFF
--- a/packages/xsel/build.sh
+++ b/packages/xsel/build.sh
@@ -1,0 +1,29 @@
+TERMUX_PKG_HOMEPAGE=http://www.kfish.org/software/xsel/
+TERMUX_PKG_DESCRIPTION="Command-line program for getting and setting the contents of the X selection"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_MAINTAINER="Doron Behar <me@doronbehar.com>"
+TERMUX_PKG_VERSION=1.2.0.20190505
+_commit=24bee9c7f4dc887eabb2783f21cbf9734d723d72
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_DEPENDS="libx11"
+TERMUX_PKG_BUILD_DEPENDS="libxt"
+
+termux_step_extract_package() {
+	mkdir -p $TERMUX_PKG_SRCDIR
+	cd $TERMUX_PKG_SRCDIR
+	git clone https://github.com/kfish/xsel
+	cd xsel
+	git checkout $_commit
+	./autogen.sh --prefix=$TERMUX_PREFIX
+}
+
+termux_step_make() {
+	cd $TERMUX_PKG_SRCDIR/xsel
+	make
+}
+
+termux_step_make_install() {
+	cd $TERMUX_PKG_SRCDIR/xsel
+	make install
+	install -D -m0644 COPYING $TERMUX_PREFIX/share/LICENSES/xsel.txt
+}

--- a/packages/xsel/build.sh
+++ b/packages/xsel/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=http://www.kfish.org/software/xsel/
 TERMUX_PKG_DESCRIPTION="Command-line program for getting and setting the contents of the X selection"
-TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Doron Behar <me@doronbehar.com>"
 TERMUX_PKG_VERSION=1.2.0.20190505
 _commit=24bee9c7f4dc887eabb2783f21cbf9734d723d72

--- a/packages/xsel/build.sh
+++ b/packages/xsel/build.sh
@@ -3,27 +3,12 @@ TERMUX_PKG_DESCRIPTION="Command-line program for getting and setting the content
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Doron Behar <me@doronbehar.com>"
 TERMUX_PKG_VERSION=1.2.0.20190505
-_commit=24bee9c7f4dc887eabb2783f21cbf9734d723d72
-TERMUX_PKG_REVISION=1
+local _COMMIT=24bee9c7f4dc887eabb2783f21cbf9734d723d72
+TERMUX_PKG_SRCURL=https://github.com/kfish/xsel/archive/24bee9c7f4dc887eabb2783f21cbf9734d723d72.zip
+TERMUX_PKG_SHA256=9b9b92deece971201d75b8932a743e8a6b597c4b146de193f54d09a58da15624
 TERMUX_PKG_DEPENDS="libx11"
 TERMUX_PKG_BUILD_DEPENDS="libxt"
 
-termux_step_extract_package() {
-	mkdir -p $TERMUX_PKG_SRCDIR
-	cd $TERMUX_PKG_SRCDIR
-	git clone https://github.com/kfish/xsel
-	cd xsel
-	git checkout $_commit
-	./autogen.sh --prefix=$TERMUX_PREFIX
-}
-
-termux_step_make() {
-	cd $TERMUX_PKG_SRCDIR/xsel
-	make
-}
-
-termux_step_make_install() {
-	cd $TERMUX_PKG_SRCDIR/xsel
-	make install
-	install -D -m0644 COPYING $TERMUX_PREFIX/share/LICENSES/xsel.txt
+termux_step_pre_configure() {
+	autoreconf -fi
 }


### PR DESCRIPTION
Hey all, I would like to add this package to the distribution. It seems
to be building fine only with this error at the end of the build:

```
ERROR: No LICENSE file was installed for xsel
```

Also, I'm not sure that I've had to write my own version of the
functions `termux_step_make` and `termux_step_make_install` but I guess
that since I've overridden `termux_step_extract_package`, this was
necessary as well.

For reference, the license upstream is:
https://github.com/kfish/xsel/blob/master/COPYING