### PR TITLE
new package: bochs

### DIFF
--- a/packages/bochs/build.sh
+++ b/packages/bochs/build.sh
@@ -1,0 +1,27 @@
+TERMUX_PKG_HOMEPAGE=http://bochs.sourceforge.net/
+TERMUX_PKG_DESCRIPTION="Bochs is a highly portable open source IA-32 (x86) PC emulator and debugger written in C++."
+TERMUX_PKG_LICENSE="LGPL-2.0"
+TERMUX_PKG_VERSION=2.6.9
+TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/bochs/bochs-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=ee5b677fd9b1b9f484b5aeb4614f43df21993088c0c0571187f93acb0866e98c
+TERMUX_PKG_DEPENDS="atk, fontconfig, freetype, gdk-pixbuf, glib, gtk2, pango-x, libandroid-shmem, libc++, libcairo-x, libgraphite, libx11, libxpm, libxrandr, ncurses"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--without-wx
+--with-x11
+--with-x
+--with-term
+--disable-docbook
+--enable-cpu-level=6
+--enable-fpu
+--enable-3dnow
+--enable-disasm
+--enable-smp
+--enable-x86-64
+--enable-avx
+--enable-long-phy-address
+--enable-disasm
+--enable-usb
+--enable-debugger
+--disable-readline
+"

--- a/packages/bochs/build.sh
+++ b/packages/bochs/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_VERSION=2.6.9
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/bochs/bochs-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ee5b677fd9b1b9f484b5aeb4614f43df21993088c0c0571187f93acb0866e98c
-TERMUX_PKG_DEPENDS="atk, fontconfig, freetype, gdk-pixbuf, glib, gtk2, pango-x, libandroid-shmem, libc++, libcairo-x, libgraphite, libx11, libxpm, libxrandr, ncurses"
+TERMUX_PKG_DEPENDS="atk, fontconfig, freetype, gdk-pixbuf, glib, gtk2, pango-x, libc++, libcairo-x, libgraphite, libx11, libxpm, libxrandr, ncurses, readline"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --without-wx
@@ -12,16 +12,16 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-x
 --with-term
 --disable-docbook
---enable-cpu-level=6
---enable-fpu
---enable-3dnow
---enable-disasm
---enable-smp
 --enable-x86-64
---enable-avx
---enable-long-phy-address
---enable-disasm
---enable-usb
+--enable-smp
 --enable-debugger
---disable-readline
+--enable-disasm
+--enable-3dnow
+--enable-avx
+--enable-usb
+--enable-usb-ehci
+--enable-ne2000
+--enable-e1000
+--enable-clgd54xx
+--enable-voodoo
 "

--- a/packages/bochs/bx_debug-Makefile.in.patch
+++ b/packages/bochs/bx_debug-Makefile.in.patch
@@ -1,0 +1,11 @@
+diff -uNr bochs-2.6.9/bx_debug/Makefile.in bochs-2.6.9.mod/bx_debug/Makefile.in
+--- bochs-2.6.9/bx_debug/Makefile.in    2016-08-13 01:06:14.000000000 +0800
++++ bochs-2.6.9.mod/bx_debug/Makefile.in        2019-08-26 21:47:49.744442900 +0800
+@@ -58,7 +58,7 @@
+
+ BX_INCLUDES = debug.h
+
+-BX_INCDIRS = -I.. -I$(srcdir)/.. -I../@INSTRUMENT_DIR@ -I$(srcdir)/../@INSTRUMENT_DIR@ -I. -I$(srcdir)/.
++BX_INCDIRS = -I.. -I/data/data/com.termux/files/usr/include -I$(srcdir)/.. -I../@INSTRUMENT_DIR@ -I$(srcdir)/../@INSTRUMENT_DIR@ -I. -I$(srcdir)/.
+
+ all: libdebug.a

--- a/packages/bochs/configure.patch
+++ b/packages/bochs/configure.patch
@@ -1,0 +1,70 @@
+diff -uNr bochs-2.6.9/configure bochs-2.6.9.mod/configure
+--- bochs-2.6.9/configure       2017-04-09 14:46:13.000000000 +0800
++++ bochs-2.6.9.mod/configure   2019-08-26 20:49:05.555477600 +0800
+@@ -22636,66 +22636,9 @@
+
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if readline works without -lcurses" >&5
+ $as_echo_n "checking if readline works without -lcurses... " >&6; }
+-    OLD_LIBS=$LIBS
+-    LIBS="$LIBS -lreadline"
+-    if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-      #include <stdio.h>
+-      #include <readline/readline.h>
+-      int main() { rl_initialize(); exit(0); }
+-
+-_ACEOF
+-if ac_fn_c_try_run "$LINENO"; then :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+         rl_without_curses_ok=yes
+-else
+-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-
+-fi
+-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
+-fi
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if readline works with -lcurses" >&5
+-$as_echo_n "checking if readline works with -lcurses... " >&6; }
+-    LIBS="$LIBS -lcurses"
+-    if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-      #include <stdio.h>
+-      #include <readline/readline.h>
+-      int main() { rl_initialize(); exit(0); }
+-
+-_ACEOF
+-if ac_fn_c_try_run "$LINENO"; then :
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
+-       rl_with_curses_ok=yes
+-else
+-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-
+-fi
+-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
+-fi
+-
+-    LIBS=$OLD_LIBS
+
+     if test "$rl_without_curses_ok" = yes; then
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/packages/bochs/gui-term.cc.patch
+++ b/packages/bochs/gui-term.cc.patch
@@ -1,0 +1,15 @@
+--- bochs-2.6.9/gui/term.cc 2017-01-15 19:44:43.000000000 +0800
++++ bochs-2.6.9.mod/gui/term.cc  2019-08-26 00:46:12.453482400 +0800
+@@ -33,7 +33,11 @@
+ #include <signal.h>
+ };
+
+-#define BX_DEBUGGER_TERM (BX_DEBUGGER && !defined(__OpenBSD__))
++#if BX_DEBUGGER && !defined(__OpenBSD__)
++#define BX_DEBUGGER_TERM 1
++#else
++#define BX_DEBUGGER_TERM 0
++#endif
+
+ class bx_term_gui_c : public bx_gui_c {
+ public:

--- a/packages/bochs/gui-term.cc.patch
+++ b/packages/bochs/gui-term.cc.patch
@@ -1,5 +1,5 @@
 --- bochs-2.6.9/gui/term.cc 2017-01-15 19:44:43.000000000 +0800
-+++ bochs-2.6.9.mod/gui/term.cc  2019-08-26 00:46:12.453482400 +0800
++++ bochs-2.6.9.mod/gui/term.cc  2019-08-26 01:29:09.440407700 +0800
 @@ -33,7 +33,11 @@
  #include <signal.h>
  };
@@ -13,3 +13,34 @@
 
  class bx_term_gui_c : public bx_gui_c {
  public:
+@@ -180,20 +184,25 @@
+   if (!strcmp(SIM->get_param_string(BXPN_LOG_FILENAME)->getptr(), "-"))
+     BX_PANIC(("cannot log to stderr in term mode"));
+ #else
+-  FILE *old_stdin = stdin;
+-  FILE *old_stdout = stdout;
++  int old_stdin = dup(STDIN_FILENO);
++  int old_stdout = dup(STDOUT_FILENO);
+   scr_fd = open("/dev/ptmx",O_RDWR);
+   if(scr_fd > 0){
+-    stdin = stdout = fdopen(scr_fd,"wr");
+     grantpt(scr_fd);
+     unlockpt(scr_fd);
++    FILE * pty = fdopen(scr_fd,"wr");
++    int pts = fileno(pty);
++    dup2(pts,STDIN_FILENO);
++    dup2(pts,STDOUT_FILENO);
+     fprintf(stderr, "\nBochs connected to screen \"%s\"\n",ptsname(scr_fd));
+   }
+ #endif
+   initscr();
+ #if BX_DEBUGGER_TERM
+-  stdin = old_stdin;
+-  stdout = old_stdout;
++  dup2(old_stdin,STDIN_FILENO);
++  dup2(old_stdout,STDOUT_FILENO);
++  close(old_stdin);
++  close(old_stdout);
+ #endif
+   start_color();
+   cbreak();

--- a/packages/bochs/gui-term.cc.patch
+++ b/packages/bochs/gui-term.cc.patch
@@ -1,5 +1,6 @@
---- bochs-2.6.9/gui/term.cc 2017-01-15 19:44:43.000000000 +0800
-+++ bochs-2.6.9.mod/gui/term.cc  2019-08-26 01:29:09.440407700 +0800
+diff -uNr bochs-2.6.9/gui/term.cc bochs-2.6.9.mod/gui/term.cc
+--- bochs-2.6.9/gui/term.cc     2017-01-15 19:44:43.000000000 +0800
++++ bochs-2.6.9.mod/gui/term.cc 2019-08-26 01:42:56.996929000 +0800
 @@ -33,7 +33,11 @@
  #include <signal.h>
  };

--- a/packages/bochs/iodev-network-slirp-misc.cc.patch
+++ b/packages/bochs/iodev-network-slirp-misc.cc.patch
@@ -1,0 +1,12 @@
+diff -uNr bochs-2.6.9/iodev/network/slirp/misc.cc bochs-2.6.9.mod/iodev/network/slirp/misc.cc
+--- bochs-2.6.9/iodev/network/slirp/misc.cc     2016-12-14 04:22:28.000000000 +0800
++++ bochs-2.6.9.mod/iodev/network/slirp/misc.cc 2019-08-26 20:05:37.060533000 +0800
+@@ -16,7 +16,7 @@
+ #include "libslirp.h"
+
+ #if BX_NETWORKING && BX_NETMOD_SLIRP
+-
++#define ANDROID
+ #ifdef DEBUG
+ int slirp_debug = DBG_CALL|DBG_MISC|DBG_ERROR;
+ #endif


### PR DESCRIPTION
**Package description**
<!--
A short and clear description of what this package do and why it should
be packaged for Termux.
-->
Bochs is a highly portable open source IA-32 (x86) PC emulator and debugger written in C++.

Although there are already some Android ports for bochs, this version has a GUI assembler debugger that is helpful for operating system development and research.

Screenshot of running Linux0.11 in bochs:
![图片](https://user-images.githubusercontent.com/8438475/63652696-c7f09c80-c795-11e9-872b-59323bee7acf.png)

**Link to home page and sources**
1. Home page: http://bochs.sourceforge.net/
2. Source code:https://sourceforge.net/projects/bochs/files/bochs/

Problem:
A warning is show when using GUI debugger(screenshot above) 
Any reason for disable X11 thread support?