### PR TITLE
Add web browser netsurf.

### DIFF
--- a/packages/netsurf/build.sh
+++ b/packages/netsurf/build.sh
@@ -1,0 +1,36 @@
+TERMUX_PKG_HOMEPAGE=http://www.netsurf-browser.org/
+TERMUX_PKG_DESCRIPTION="NetSurf is a free, open source web browser. It is written in C and released under the GNU Public Licence version 2. NetSurf has its own layout and rendering engine entirely written from scratch. It is small and capable of handling many of the web standards in use today."
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com>"
+TERMUX_PKG_VERSION=3.9
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=http://download.netsurf-browser.org/netsurf/releases/source-full/netsurf-all-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=11e384eaf47e65c186da5001f1055a02f2d72ff17b50f403b8392546a2cf65ff
+TERMUX_PKG_DEPENDS="desktop-file-utils, exo, libjpeg-turbo, libpng, gtk3, openssl, libcurl, libiconv"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-gtk3"
+TERMUX_PKG_BUILD_IN_SRC=true
+termux_step_configure () {
+    echo CC=$CC
+	export HOST=`$CC -dumpmachine`
+	export BUILD=`$CC_FOR_BUILD -dumpmachine`
+	export CFLAGS+=" -I${TERMUX_PREFIX}/include"
+	export CPPFLAGS+=" -I${TERMUX_PREFIX}/include"
+	export CXXFLAGS+=" -I${TERMUX_PREFIX}/include"
+	mkdir -p netsurf/build/Linux-gtk3
+	# Note: NETSURF_USE_DUKTAPE= disables javascript, because I couldn't figure out how to build
+	# required the nsgenbind tool so that it can be executed on the *host* (it is used during the build process only)
+    make PREFIX="${TERMUX_PREFIX}" NETSURF_GTK_MAJOR=3 NETSURF_USE_DUKTAPE=NO NETSURF_USE_LIBICONV_PLUG=NO toolchain=clang
+}
+termux_step_make() {
+	# Nothing to do 
+    echo CC=$CC
+}
+termux_step_make_install () {
+    echo CC=$CC
+	export HOST=`$CC -dumpmachine`
+	export BUILD=`$CC_FOR_BUILD -dumpmachine`
+	export CFLAGS+=" -I${TERMUX_PREFIX}/include"
+	export CPPFLAGS+=" -I${TERMUX_PREFIX}/include"
+	export CXXFLAGS+=" -I${TERMUX_PREFIX}/include"
+    make install PREFIX="${TERMUX_PREFIX}" NETSURF_GTK_MAJOR=3 NETSURF_USE_DUKTAPE=NO NETSURF_USE_LIBICONV_PLUG=NO toolchain=clang
+} 


### PR DESCRIPTION
Tested on Android 9 device.
Currently I had to disable Javascript support ("Duktape") because I wasn't able to figure out how to build the required nsgenbind tool so that it can be executed on the *host* (it is used during the build process only). 
Shouldn't be a large issue though because Netsurf's Javascript support is very rudimentary anyway and will not really be missed.