### PR TITLE
Add package: chocolate-doom

### DIFF
--- a/packages/chocolate-doom/build.sh
+++ b/packages/chocolate-doom/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_VERSION=3.0.1
 TERMUX_PKG_SRCURL=https://github.com/chocolate-doom/chocolate-doom/archive/refs/tags/chocolate-doom-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a54383beef6a52babc5b00d58fcf53a454f012ced7b1936ba359b13f1f10ac66
 TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net"
+TERMUX_PKG_BLACKLISTED_ARCHES="x86_64"
 
 termux_step_pre_configure(){
 	NOCONFIGURE=1 ./autogen.sh

--- a/packages/chocolate-doom/build.sh
+++ b/packages/chocolate-doom/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_VERSION=3.0.1
 TERMUX_PKG_SRCURL=https://github.com/chocolate-doom/chocolate-doom/archive/refs/tags/chocolate-doom-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a54383beef6a52babc5b00d58fcf53a454f012ced7b1936ba359b13f1f10ac66
 TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net"
-TERMUX_PKG_BLACKLISTED_ARCHES="x86_64"
 
 termux_step_pre_configure(){
     autoreconf -fi

--- a/packages/chocolate-doom/build.sh
+++ b/packages/chocolate-doom/build.sh
@@ -7,7 +7,3 @@ TERMUX_PKG_SRCURL=https://github.com/chocolate-doom/chocolate-doom/archive/refs/
 TERMUX_PKG_SHA256=a54383beef6a52babc5b00d58fcf53a454f012ced7b1936ba359b13f1f10ac66
 TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net"
 TERMUX_PKG_BLACKLISTED_ARCHES="x86_64"
-
-termux_step_pre_configure(){
-	NOCONFIGURE=1 ./autogen.sh
-}

--- a/packages/chocolate-doom/build.sh
+++ b/packages/chocolate-doom/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://www.chocolate-doom.org
+TERMUX_PKG_DESCRIPTION="Historically-accurate Doom, Heretic, Hexen, and Strife ports."
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="WMCB-Tech @marcusz"
+TERMUX_PKG_VERSION=3.0.1
+TERMUX_PKG_SRCURL=https://github.com/chocolate-doom/chocolate-doom/archive/refs/tags/chocolate-doom-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=a54383beef6a52babc5b00d58fcf53a454f012ced7b1936ba359b13f1f10ac66
+TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net"
+
+termux_step_pre_configure(){
+	NOCONFIGURE=1 ./autogen.sh
+}

--- a/packages/chocolate-doom/build.sh
+++ b/packages/chocolate-doom/build.sh
@@ -7,3 +7,7 @@ TERMUX_PKG_SRCURL=https://github.com/chocolate-doom/chocolate-doom/archive/refs/
 TERMUX_PKG_SHA256=a54383beef6a52babc5b00d58fcf53a454f012ced7b1936ba359b13f1f10ac66
 TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net"
 TERMUX_PKG_BLACKLISTED_ARCHES="x86_64"
+
+termux_step_pre_configure(){
+    NOCONFIGURE=1 ./autogen.sh
+}

--- a/packages/chocolate-doom/build.sh
+++ b/packages/chocolate-doom/build.sh
@@ -9,5 +9,5 @@ TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net"
 TERMUX_PKG_BLACKLISTED_ARCHES="x86_64"
 
 termux_step_pre_configure(){
-    NOCONFIGURE=1 ./autogen.sh
+    autoreconf -fi
 }


### PR DESCRIPTION
This package allows users to run WAD files such as Doom, Hexen, Heretic, etc,

Of course, for better experience, Samsung DeX or External VNC Display with mouse and keyboard is recommended