### PR TITLE
updates qtbase and qtdeclarative for host building

### DIFF
--- a/packages/qt5-qtbase/build.sh
+++ b/packages/qt5-qtbase/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A cross-platform application and UI framework"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION=5.12.10
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/5.12/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=8088f174e6d28e779516c083b6087b6a9e3c8322b4bc161fd1b54195e3c86940
 TERMUX_PKG_DEPENDS="dbus, harfbuzz, libandroid-shmem, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, openssl, pcre2, ttf-dejavu, freetype, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib"
@@ -98,13 +98,7 @@ termux_step_configure () {
         -no-feature-systemsemaphore
 }
 
-termux_step_make() {
-    make -j "${TERMUX_MAKE_PROCESSES}"
-}
-
-termux_step_make_install() {
-    make install
-
+termux_step_post_make_install() {
     #######################################################
     ##
     ##  Compiling necessary libraries for target.
@@ -182,6 +176,15 @@ termux_step_make_install() {
     sed -i \
         's|/lib/qt//mkspecs/termux-cross"|/lib/qt/mkspecs/termux"|g' \
         "${TERMUX_PREFIX}/lib/cmake/Qt5Core/Qt5CoreConfigExtrasMkspecDir.cmake"
+
+
+    ## Create qmake.conf suitable for compiling host tools (for other modules)
+    install -Dm644 \
+        "${TERMUX_PKG_BUILDER_DIR}/qmake.host.conf" \
+        "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qmake.conf"
+    install -Dm644 \
+        "${TERMUX_PKG_BUILDER_DIR}/qplatformdefs.host.h" \
+        "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qplatformdefs.h"
 }
 
 termux_step_create_debscripts() {

--- a/packages/qt5-qtbase/qmake.host.conf
+++ b/packages/qt5-qtbase/qmake.host.conf
@@ -7,23 +7,9 @@ QMAKE_INCREMENTAL_STYLE = sublib
 
 include(../common/linux.conf)
 include(../common/gcc-base-unix.conf)
-include(../common/clang.conf)
-
-QMAKE_CC                = gcc
-QMAKE_CXX               = g++
-QMAKE_LINK              = $${QMAKE_CXX}
-QMAKE_LINK_SHLIB        = $${QMAKE_CXX}
-QMAKE_AR                = ar cqs
-QMAKE_NM                = nm -P
-QMAKE_OBJCOPY           = objcopy
-QMAKE_PKG_CONFIG        = pkg-config
-QMAKE_STRIP             = strip
+include(../common/g++-unix.conf)
 
 QMAKE_CFLAGS           += -I/data/data/com.termux/files/usr/include
 QMAKE_CXXFLAGS         += -I/data/data/com.termux/files/usr/include
-QMAKE_LFLAGS_SHLIB     += -shared
-QMAKE_LFLAGS_PLUGIN    += -shared
-
-QMAKE_LIBS_THREAD       = -lpthread
 
 load(qt_config)

--- a/packages/qt5-qtbase/qmake.host.conf
+++ b/packages/qt5-qtbase/qmake.host.conf
@@ -1,0 +1,29 @@
+# This configuration is for the termux builder (Ubuntu glibc)
+QT_QPA_DEFAULT_PLATFORM = xcb
+
+MAKEFILE_GENERATOR      = UNIX
+CONFIG                 += incremental
+QMAKE_INCREMENTAL_STYLE = sublib
+
+include(../common/linux.conf)
+include(../common/gcc-base-unix.conf)
+include(../common/clang.conf)
+
+QMAKE_CC                = gcc
+QMAKE_CXX               = g++
+QMAKE_LINK              = $${QMAKE_CXX}
+QMAKE_LINK_SHLIB        = $${QMAKE_CXX}
+QMAKE_AR                = ar cqs
+QMAKE_NM                = nm -P
+QMAKE_OBJCOPY           = objcopy
+QMAKE_PKG_CONFIG        = pkg-config
+QMAKE_STRIP             = strip
+
+QMAKE_CFLAGS           += -I/data/data/com.termux/files/usr/include
+QMAKE_CXXFLAGS         += -I/data/data/com.termux/files/usr/include
+QMAKE_LFLAGS_SHLIB     += -shared
+QMAKE_LFLAGS_PLUGIN    += -shared
+
+QMAKE_LIBS_THREAD       = -lpthread
+
+load(qt_config)

--- a/packages/qt5-qtbase/qplatformdefs.host.h
+++ b/packages/qt5-qtbase/qplatformdefs.host.h
@@ -1,0 +1,4 @@
+#include "../android-clang/qplatformdefs.h"
+#define fseeko64 fseeko
+#define ftello64 ftello
+#define fopen64 fopen

--- a/packages/qt5-qtbase/qt5-qtbase-cross-tools.subpackage.sh
+++ b/packages/qt5-qtbase/qt5-qtbase-cross-tools.subpackage.sh
@@ -1,7 +1,9 @@
-TERMUX_SUBPKG_DESCRIPTION="Tools for cross build on the host machine"
+TERMUX_SUBPKG_DESCRIPTION="Tools for cross build on the host (NOT for Termux)"
 TERMUX_SUBPKG_DEPENDS="qt5-qtbase"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
 TERMUX_SUBPKG_INCLUDE="
 opt/qt/cross/bin/*
 opt/qt/cross/lib/*
 lib/qt/mkspecs/termux-cross/*
+lib/qt/mkspecs/termux-host/*
 "

--- a/packages/qt5-qtdeclarative/build.sh
+++ b/packages/qt5-qtdeclarative/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The Qt Declarative module provides classes for using GUI
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION=5.12.10
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/5.12/${TERMUX_PKG_VERSION}/submodules/qtdeclarative-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=ae56708646954f93eae087f20408fdbce9b977af565202ddcb4a3119e90f8a16
 TERMUX_PKG_DEPENDS="qt5-qtbase"
@@ -11,9 +11,9 @@ TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STATICSPLIT=true
 
-# Not packaging the host tools and libraries for now (unlikely to be useful)
+# Ignore bootstrap changes because of the hijacking
 TERMUX_PKG_RM_AFTER_INSTALL="
-opt/qt
+opt/qt/cross/lib/libQt5Bootstrap.*
 "
 
 # Replacing the old qt5-base packages
@@ -22,7 +22,7 @@ TERMUX_PKG_REPLACES="qt5-declarative"
 termux_step_pre_configure () {
     #######################################################
     ##
-    ##  Hijack the bootstrap library
+    ##  Hijack the bootstrap library for cross building
     ##
     #######################################################
     for i in a prl; do
@@ -39,16 +39,40 @@ termux_step_configure () {
         -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
 }
 
-termux_step_make() {
-    make -j "${TERMUX_MAKE_PROCESSES}"
-}
-
-termux_step_make_install() {
-    make install
-
+termux_step_post_make_install () {
     #######################################################
     ##
     ##  Compiling necessary binaries for target.
+    ##
+    #######################################################
+
+    ## Qt Declarative utilities.
+    for i in qmlcachegen qmlimportscanner qmllint qmlmin; do
+        cd "${TERMUX_PKG_SRCDIR}/tools/${i}" && {
+            "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
+                -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
+
+            make -j "${TERMUX_MAKE_PROCESSES}"
+            install -Dm700 "../../bin/${i}" "${TERMUX_PREFIX}/bin/${i}"
+        }
+    done
+
+    #######################################################
+    ##
+    ##  Restore the bootstrap library
+    ##
+    #######################################################
+    for i in a prl; do
+        rm -f "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}"
+        cp -p "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}.bak" \
+            "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}"
+        rm -f "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}.bak"
+    done
+    unset i
+
+    #######################################################
+    ##
+    ##  Compiling necessary binaries for the host
     ##
     #######################################################
 
@@ -57,11 +81,11 @@ termux_step_make_install() {
         make clean
 
         "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
-            -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
+            -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host"
 
         make -j "${TERMUX_MAKE_PROCESSES}"
-        install -Dm644 ../../lib/libQt5QmlDevTools.a "${TERMUX_PREFIX}/lib/libQt5QmlDevTools.a"
-        install -Dm644 ../../lib/libQt5QmlDevTools.prl "${TERMUX_PREFIX}/lib/libQt5QmlDevTools.prl"
+        install -Dm644 ../../lib/libQt5QmlDevTools.a "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5QmlDevTools.a"
+        install -Dm644 ../../lib/libQt5QmlDevTools.prl "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5QmlDevTools.prl"
     }
 
     ## Qt Declarative utilities.
@@ -70,10 +94,10 @@ termux_step_make_install() {
             make clean
 
             "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
-                -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
+                -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host"
 
             make -j "${TERMUX_MAKE_PROCESSES}"
-            install -Dm700 "../../bin/${i}" "${TERMUX_PREFIX}/bin/${i}"
+            install -Dm700 "../../bin/${i}" "${TERMUX_PREFIX}/opt/qt/cross/bin/${i}"
         }
     done
 
@@ -93,19 +117,6 @@ termux_step_make_install() {
 
     ## Remove *.la files.
     find "${TERMUX_PREFIX}/lib" -iname \*.la -delete
-
-
-    #######################################################
-    ##
-    ##  Restore the bootstrap library
-    ##
-    #######################################################
-    for i in a prl; do
-        rm -f "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}"
-        cp -p "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}.bak" \
-            "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}"
-        rm -f "${TERMUX_PREFIX}/opt/qt/cross/lib/libQt5Bootstrap.${i}.bak"
-    done
-    unset i
+    find "${TERMUX_PREFIX}/opt/qt/cross/lib" -iname \*.la -delete
 }
 

--- a/packages/qt5-qtdeclarative/build.sh
+++ b/packages/qt5-qtdeclarative/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The Qt Declarative module provides classes for using GUI
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION=5.12.10
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/5.12/${TERMUX_PKG_VERSION}/submodules/qtdeclarative-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=ae56708646954f93eae087f20408fdbce9b977af565202ddcb4a3119e90f8a16
 TERMUX_PKG_DEPENDS="qt5-qtbase"
@@ -56,6 +56,10 @@ termux_step_post_make_install () {
             install -Dm700 "../../bin/${i}" "${TERMUX_PREFIX}/bin/${i}"
         }
     done
+
+    # Install the QmlDevTools for target (needed by some packages such as qttools)
+    install -Dm644 ${TERMUX_PKG_SRCDIR}/lib/libQt5QmlDevTools.a "${TERMUX_PREFIX}/lib/libQt5QmlDevTools.a"
+    install -Dm644 ${TERMUX_PKG_SRCDIR}/lib/libQt5QmlDevTools.prl "${TERMUX_PREFIX}/lib/libQt5QmlDevTools.prl"
 
     #######################################################
     ##

--- a/packages/qt5-qtdeclarative/qt5-qtdeclarative-cross-tools.subpackage.sh
+++ b/packages/qt5-qtdeclarative/qt5-qtdeclarative-cross-tools.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Qt declarative module for cross build (NOT for Termux)"
+TERMUX_SUBPKG_DEPENDS="qt5-qtdeclarative"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
+TERMUX_SUBPKG_INCLUDE="
+opt/qt/cross/*
+"


### PR DESCRIPTION
adding a dedicated termux host building spec (`linux-g++` is not working when building `qttools` because of the messy include chain hacked by us for termux which resulted in redefinition of structs). this `termux-host` seems working

additionally, making the host tools arch independent since it is for the host and not for termux