### PR TITLE
add otter-browser, QtWebKit and their dependencies

### DIFF
--- a/packages/otter-browser/build.sh
+++ b/packages/otter-browser/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://otter-browser.org
+TERMUX_PKG_DESCRIPTION="Web browser with aspects of Opera (12.x)"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
+TERMUX_PKG_VERSION=1.0.02
+TERMUX_PKG_SRCURL="https://github.com/OtterBrowser/otter-browser/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=d1e090a80fa736cd128f594184817078a08cac31614e85e7838ff1b64511d62d
+TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtsvg, qt5-qtxmlpatterns, qt5-qtwebkit, qt5-qtmultimedia, hunspell"
+TERMUX_PKG_BUILD_DEPENDS="cmake"
+TERMUX_PKG_NO_STATICSPLIT=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DENABLE_QTWEBENGINE=OFF -DENABLE_QTWEBKIT=ON -DENABLE_CRASHREPORTS=OFF -DENABLE_SPELLCHECK=ON"

--- a/packages/qt5-qtlocation/build.sh
+++ b/packages/qt5-qtlocation/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE=https://www.qt.io/
+TERMUX_PKG_DESCRIPTION="Qt 5 Location Library"
+TERMUX_PKG_LICENSE="LGPL-3.0"
+TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
+TERMUX_PKG_VERSION=5.12.10
+TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/5.12/${TERMUX_PKG_VERSION}/submodules/qtlocation-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=ac1172b0dabd63fb256fe89db2fc41fd89eb2de54a828975b8ddd298cc07efb3
+TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true
+
+termux_step_configure () {
+    "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
+        -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
+}
+
+termux_step_post_make_install() {
+    #######################################################
+    ##
+    ##  Fixes & cleanup.
+    ##
+    #######################################################
+
+    ## Drop QMAKE_PRL_BUILD_DIR because reference the build dir.
+    find "${TERMUX_PREFIX}/lib" -type f -name "libQt5Location*.prl" \
+        -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' "{}" \;
+    find "${TERMUX_PREFIX}/lib" -type f -name "libQt5Position*.prl" \
+        -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' "{}" \;
+
+    ## Remove *.la files.
+    find "${TERMUX_PREFIX}/lib" -iname \*.la -delete
+}
+

--- a/packages/qt5-qtmultimedia/build.sh
+++ b/packages/qt5-qtmultimedia/build.sh
@@ -3,20 +3,22 @@ TERMUX_PKG_DESCRIPTION="Qt 5 Multimedia Library"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION=5.12.10
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/5.12/${TERMUX_PKG_VERSION}/submodules/qtmultimedia-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=cc98f19eb54b581f4a270855c4dc07ae9272e775ae7c5729c885e6c5e197a03c
 # qt5-qtdeclarative is not needed because quick widget requires OpenGL
-# gstreamer is not supported because it requires glib and Qt OpenGL support
-TERMUX_PKG_DEPENDS="qt5-qtbase, pulseaudio, openal-soft"
-TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, fdupes"
+TERMUX_PKG_DEPENDS="qt5-qtbase, pulseaudio, openal-soft, gstreamer, gst-plugins-base, gst-plugins-bad"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STATICSPLIT=true
 
 termux_step_configure () {
     "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
-        -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
-    # GST_VERSION=1.0 if/when OpenGL is supported
+        -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross" \
+        GST_VERSION=1.0 \
+        INCLUDEPATH+="${TERMUX_PREFIX}/include/gstreamer-1.0/" \
+        INCLUDEPATH+="${TERMUX_PREFIX}/include/glib-2.0/" \
+        INCLUDEPATH+="${TERMUX_PREFIX}/lib/glib-2.0/include"
 }
 
 termux_step_make_install() {

--- a/packages/qt5-qtmultimedia/detect_libs_without_pkg_config.patch
+++ b/packages/qt5-qtmultimedia/detect_libs_without_pkg_config.patch
@@ -6,7 +6,7 @@
              "sources": [
 -                { "type": "pkgConfig", "args": "gstreamer-app-1.0" }
 +                { "type": "pkgConfig", "args": "gstreamer-app-1.0" },
-+                { "libs": "-lgstapp-1.0" }
++                { "libs": "-lgstapp-1.0 -lgstbase-1.0 -lgstreamer-1.0 -lgobject-2.0 -lglib-2.0" }
              ]
          },
          "gstreamer_photography_0_10": {
@@ -20,3 +20,15 @@
              ]
          },
          "wmf": {
+--- src/src/multimedia/configure.json   2021-05-16 13:53:50.128205372 +0000
++++ src.mod/src/multimedia/configure.json       2021-05-16 13:41:51.186432131 +0000
+@@ -53,7 +53,8 @@
+             "test": "gstreamer",
+             "sources": [
+                 { "type": "pkgConfig",
+-                  "args": "gstreamer-1.0 gstreamer-base-1.0 gstreamer-audio-1.0 gstreamer-video-1.0 gstreamer-pbutils-1.0" }
++                  "args": "gstreamer-1.0 gstreamer-base-1.0 gstreamer-audio-1.0 gstreamer-video-1.0 gstreamer-pbutils-1.0" },
++                { "libs": "-lgstpbutils-1.0 -lgstaudio-1.0 -lgstvideo-1.0 -lgstbase-1.0 -lgsttag-1.0 -lgstreamer-1.0 -lgobject-2.0 -lglib-2.0" }
+             ]
+         },
+         "gstreamer_app_0_10": {

--- a/packages/qt5-qtmultimedia/gst_include_path.patch
+++ b/packages/qt5-qtmultimedia/gst_include_path.patch
@@ -1,0 +1,29 @@
+--- src/config.tests/gstreamer/gstreamer.pro	2020-10-15 06:53:20.000000000 +0000
++++ src.mod/config.tests/gstreamer/gstreamer.pro	2021-05-16 13:59:14.419703082 +0000
+@@ -1,2 +1,5 @@
+ SOURCES += main.cpp
+ 
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/gstreamer-1.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/glib-2.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/lib/glib-2.0/include"
+--- src/config.tests/gstreamer_photography/gstreamer_photography.pro	2020-10-15 06:53:20.000000000 +0000
++++ src.mod/config.tests/gstreamer_photography/gstreamer_photography.pro	2021-05-16 13:59:57.407079643 +0000
+@@ -1 +1,4 @@
+ SOURCES += main.cpp
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/gstreamer-1.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/glib-2.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/lib/glib-2.0/include"
+--- src/config.tests/gstreamer_appsrc/gstreamer_appsrc.pro	2020-10-15 06:53:20.000000000 +0000
++++ src.mod/config.tests/gstreamer_appsrc/gstreamer_appsrc.pro	2021-05-16 14:03:35.948676966 +0000
+@@ -1 +1,4 @@
+ SOURCES += main.cpp
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/gstreamer-1.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/glib-2.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/lib/glib-2.0/include"
+--- src/config.tests/gstreamer_encodingprofiles/gstreamer_encodingprofiles.pro	2020-10-15 06:53:20.000000000 +0000
++++ src.mod/config.tests/gstreamer_encodingprofiles/gstreamer_encodingprofiles.pro	2021-05-16 14:02:47.817110561 +0000
+@@ -1 +1,4 @@
+ SOURCES += main.cpp
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/gstreamer-1.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/include/glib-2.0/"
++INCLUDEPATH += "/data/data/com.termux/files/usr/lib/glib-2.0/include"

--- a/packages/qt5-qtsensors/build.sh
+++ b/packages/qt5-qtsensors/build.sh
@@ -1,0 +1,32 @@
+TERMUX_PKG_HOMEPAGE=https://www.qt.io/
+TERMUX_PKG_DESCRIPTION="Qt 5 Sensors Library"
+TERMUX_PKG_LICENSE="LGPL-3.0"
+TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
+TERMUX_PKG_VERSION=5.12.10
+TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/${TERMUX_PKG_NAME#qt5-}-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=b508dc30eef7fe4171f5426e7a234a47e54457bce3910722937c1eb6a505c081
+TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true
+
+termux_step_configure () {
+    "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
+        -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
+}
+
+termux_step_post_make_install() {
+    #######################################################
+    ##
+    ##  Fixes & cleanup.
+    ##
+    #######################################################
+
+    ## Drop QMAKE_PRL_BUILD_DIR because reference the build dir.
+    find "${TERMUX_PREFIX}/lib" -type f -name "libQt5Sensors*.prl" \
+        -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' "{}" \;
+
+    ## Remove *.la files.
+    find "${TERMUX_PREFIX}/lib" -iname \*.la -delete
+}
+

--- a/packages/qt5-qtsensors/no_librt.patch
+++ b/packages/qt5-qtsensors/no_librt.patch
@@ -1,0 +1,31 @@
+--- src/src/plugins/sensors/dummy/dummy.pro	2020-10-15 06:53:19.000000000 +0000
++++ src.mod/src/plugins/sensors/dummy/dummy.pro	2021-05-14 14:22:51.194482639 +0000
+@@ -12,8 +12,6 @@
+ 
+ OTHER_FILES = plugin.json
+ 
+-unix:!darwin:!qnx:!android:!openbsd: LIBS += -lrt
+-
+ PLUGIN_TYPE = sensors
+ PLUGIN_CLASS_NAME = dummySensorPlugin
+ load(qt_plugin)
+--- src/src/plugins/sensors/linux/linux.pro	2020-10-15 06:53:19.000000000 +0000
++++ src.mod/src/plugins/sensors/linux/linux.pro	2021-05-14 14:22:09.604788205 +0000
+@@ -3,7 +3,6 @@
+ 
+ OTHER_FILES = plugin.json
+ 
+-!android:LIBS += -lrt
+ HEADERS += linuxsysaccelerometer.h
+ SOURCES += linuxsysaccelerometer.cpp \
+ main.cpp
+--- src/src/plugins/sensors/iio-sensor-proxy/iio-sensor-proxy.pro	2020-10-15 06:53:19.000000000 +0000
++++ src.mod/src/plugins/sensors/iio-sensor-proxy/iio-sensor-proxy.pro	2021-05-14 14:28:09.397847029 +0000
+@@ -5,7 +5,6 @@
+ PLUGIN_CLASS_NAME = IIOSensorProxySensorPlugin
+ load(qt_plugin)
+ 
+-!android:LIBS += -lrt
+ HEADERS += iiosensorproxysensorbase.h \
+     iiosensorproxylightsensor.h \
+     iiosensorproxyorientationsensor.h \

--- a/packages/qt5-qtwebchannel/build.sh
+++ b/packages/qt5-qtwebchannel/build.sh
@@ -1,0 +1,32 @@
+TERMUX_PKG_HOMEPAGE=https://www.qt.io/
+TERMUX_PKG_DESCRIPTION="Qt 5 WebChannel Library"
+TERMUX_PKG_LICENSE="LGPL-3.0"
+TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
+TERMUX_PKG_VERSION=5.12.10
+TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/${TERMUX_PKG_NAME#qt5-}-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=e8495f66ea7797141926fe54d8774c86adf3bbbee06243adb593e3ad1eceb7ca
+TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative, qt5-qtwebsockets"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true
+
+termux_step_configure () {
+    "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
+        -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
+}
+
+termux_step_post_make_install() {
+    #######################################################
+    ##
+    ##  Fixes & cleanup.
+    ##
+    #######################################################
+
+    ## Drop QMAKE_PRL_BUILD_DIR because reference the build dir.
+    find "${TERMUX_PREFIX}/lib" -type f -name "libQt5WebChannel*.prl" \
+        -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' "{}" \;
+
+    ## Remove *.la files.
+    find "${TERMUX_PREFIX}/lib" -iname \*.la -delete
+}
+

--- a/packages/qt5-qtwebkit/0001-Remove-invalid-g_object-declarations-to-fix-build-wi.patch
+++ b/packages/qt5-qtwebkit/0001-Remove-invalid-g_object-declarations-to-fix-build-wi.patch
@@ -1,0 +1,30 @@
+From 5b698ba3faffd4e198a45be9fe74f53307395e4b Mon Sep 17 00:00:00 2001
+From: Fabian Vogt <fvogt@suse.de>
+Date: Wed, 7 Apr 2021 13:38:09 +0200
+Subject: [PATCH] Remove invalid g_object declarations to fix build with glib
+ >= 2.68
+
+g_object_ref_sink is defined as a macro meanwhile and so the build fails.
+Just remove the declarations, glib.h is included anyway.
+
+(Backported to 5.212. The glib include was added later, so the description
+didn't match yet.)
+---
+ Source/WTF/wtf/glib/GRefPtr.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+Index: qtwebkit-5.212.0-alpha4/Source/WTF/wtf/glib/GRefPtr.h
+===================================================================
+--- qtwebkit-5.212.0-alpha4.orig/Source/WTF/wtf/glib/GRefPtr.h
++++ qtwebkit-5.212.0-alpha4/Source/WTF/wtf/glib/GRefPtr.h
+@@ -28,9 +28,7 @@
+ #include <wtf/GetPtr.h>
+ #include <wtf/RefPtr.h>
+ #include <algorithm>
+-
+-extern "C" void g_object_unref(gpointer);
+-extern "C" gpointer g_object_ref_sink(gpointer);
++#include <glib.h>
+ 
+ namespace WTF {
+ 

--- a/packages/qt5-qtwebkit/build.sh
+++ b/packages/qt5-qtwebkit/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Qt 5 WebKit Library"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION="5.212.0-alpha4"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-${TERMUX_PKG_VERSION}/qtwebkit-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=9ca126da9273664dd23a3ccd0c9bebceb7bb534bddd743db31caf6a5a6d4a9e6
-TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative, qt5-qtlocation, qt5-qtsensors, zlib, libxslt, libxcomposite, libhyphen, libwebp, gst-plugins-base, gstreamer"
+TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative, qt5-qtlocation, qt5-qtmultimedia, qt5-qtsensors, zlib, libxslt, libxcomposite, libhyphen, libwebp"
 TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, procps, bison, flex, gperf, ruby, cmake"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DPORT=Qt -DUSE_GSTREAMER=ON -DENABLE_OPENGL=OFF -DENABLE_SAMPLING_PROFILER=OFF -DENABLE_WEBKIT2=OFF"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DPORT=Qt -DUSE_LD_GOLD=OFF -DUSE_GSTREAMER=OFF -DUSE_QT_MULTIMEDIA=ON -DENABLE_OPENGL=OFF -DENABLE_SAMPLING_PROFILER=OFF -DENABLE_WEBKIT2=OFF"
 # TODO SAMPLING_PROFILER requires glibc. We might be able to patch the source to make it work with bionic

--- a/packages/qt5-qtwebkit/build.sh
+++ b/packages/qt5-qtwebkit/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/qtwebkit/qtwebkit
+TERMUX_PKG_DESCRIPTION="Qt 5 WebKit Library"
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
+TERMUX_PKG_VERSION="5.212.0-alpha4"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-${TERMUX_PKG_VERSION}/qtwebkit-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=9ca126da9273664dd23a3ccd0c9bebceb7bb534bddd743db31caf6a5a6d4a9e6
+TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative, qt5-qtlocation, qt5-qtsensors, zlib, libxslt, libxcomposite, libhyphen, libwebp, gst-plugins-base, gstreamer"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, qt5-qttools-cross-tools, procps, bison, flex, gperf, ruby, cmake"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DPORT=Qt -DUSE_GSTREAMER=ON -DENABLE_OPENGL=OFF -DENABLE_SAMPLING_PROFILER=OFF -DENABLE_WEBKIT2=OFF"
+# TODO SAMPLING_PROFILER requires glibc. We might be able to patch the source to make it work with bionic

--- a/packages/qt5-qtwebkit/build.sh
+++ b/packages/qt5-qtwebkit/build.sh
@@ -7,6 +7,6 @@ TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-${TERMUX_PKG_VERSION}/qtwebkit-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=9ca126da9273664dd23a3ccd0c9bebceb7bb534bddd743db31caf6a5a6d4a9e6
 TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative, qt5-qtlocation, qt5-qtsensors, zlib, libxslt, libxcomposite, libhyphen, libwebp, gst-plugins-base, gstreamer"
-TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, qt5-qttools-cross-tools, procps, bison, flex, gperf, ruby, cmake"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, procps, bison, flex, gperf, ruby, cmake"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DPORT=Qt -DUSE_GSTREAMER=ON -DENABLE_OPENGL=OFF -DENABLE_SAMPLING_PROFILER=OFF -DENABLE_WEBKIT2=OFF"
 # TODO SAMPLING_PROFILER requires glibc. We might be able to patch the source to make it work with bionic

--- a/packages/qt5-qtwebkit/icu-68.patch
+++ b/packages/qt5-qtwebkit/icu-68.patch
@@ -1,0 +1,124 @@
+commit 335f29d266c5b169ff1e781f9851a3a203f3198c
+Author:     Andreas Sturmlechner <asturm@gentoo.org>
+AuthorDate: 2020-11-06 08:22:15 +0000
+Subject:    dev-qt/qtwebkit: Fix build with ICU-68
+--- a/Source/WebCore/platform/text/icu/UTextProvider.h
++++ b/Source/WebCore/platform/text/icu/UTextProvider.h
+@@ -80,12 +80,12 @@
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex >= nativeLength && text->chunkNativeLimit == nativeLength) {
+             text->chunkOffset = text->chunkLength;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     } else {
+@@ -94,12 +94,12 @@
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex <= 0 && !text->chunkNativeStart) {
+             text->chunkOffset = 0;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     }
+--- a/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
+@@ -100,23 +100,23 @@
+         if (index < uText->chunkNativeLimit && index >= uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (index >= length && uText->chunkNativeLimit == length) {
+             // Off the end of the buffer, but we can't get it.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return FALSE;
++            return false;
+         }
+     } else {
+         if (index <= uText->chunkNativeLimit && index > uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (!index && !uText->chunkNativeStart) {
+             // Already at the beginning; can't go any farther.
+             uText->chunkOffset = 0;
+-            return FALSE;
++            return false;
+         }
+     }
+     
+@@ -144,7 +144,7 @@
+ 
+     uText->nativeIndexingLimit = uText->chunkLength;
+ 
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, UChar* dest, int32_t destCapacity, UErrorCode* status)
+@@ -336,7 +336,7 @@
+ static UBool uTextLatin1ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextLatin1ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -356,7 +356,7 @@
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textLatin1ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)
+--- a/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
+@@ -125,7 +125,7 @@
+ static UBool uTextUTF16ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextUTF16ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -145,7 +145,7 @@
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textUTF16ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)
+--- a/Source/WebCore/platform/text/TextCodecICU.cpp
++++ b/Source/WebCore/platform/text/TextCodecICU.cpp
+@@ -308,7 +308,7 @@
+     m_converterICU = ucnv_open(m_canonicalConverterName, &err);
+     ASSERT(U_SUCCESS(err));
+     if (m_converterICU)
+-        ucnv_setFallback(m_converterICU, TRUE);
++        ucnv_setFallback(m_converterICU, true);
+ }
+ 
+ int TextCodecICU::decodeToBuffer(UChar* target, UChar* targetLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode& err)

--- a/packages/qt5-qtwebkit/no_execinfo_header.patch
+++ b/packages/qt5-qtwebkit/no_execinfo_header.patch
@@ -1,0 +1,20 @@
+--- src/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp	2021-05-14 19:39:34.587524906 +0000
++++ src.mod/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp	2021-05-14 19:38:52.431421074 +0000
+@@ -49,7 +49,7 @@
+ #include <wtf/Stopwatch.h>
+ 
+ #include <cxxabi.h>
+-#if OS(DARWIN) || (OS(LINUX) && !PLATFORM(GTK))
++#if OS(DARWIN) || (OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__))
+ #include <dlfcn.h>
+ #include <execinfo.h>
+ #endif
+@@ -187,7 +187,7 @@
+ 
+ void JSGlobalObjectInspectorController::appendAPIBacktrace(ScriptCallStack* callStack)
+ {
+-#if OS(DARWIN) || (OS(LINUX) && !PLATFORM(GTK))
++#if OS(DARWIN) || (OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__))
+     static const int framesToShow = 31;
+     static const int framesToSkip = 3; // WTFGetBacktrace, appendAPIBacktrace, reportAPIException.
+ 

--- a/packages/qt5-qtwebkit/tools_qttestbrowser_launcherwindow_no_opengl.patch
+++ b/packages/qt5-qtwebkit/tools_qttestbrowser_launcherwindow_no_opengl.patch
@@ -1,0 +1,127 @@
+--- src/Tools/QtTestBrowser/launcherwindow.h	2021-05-15 10:11:33.614702181 +0000
++++ src.mod/Tools/QtTestBrowser/launcherwindow.h	2021-05-15 10:07:13.279616364 +0000
+@@ -35,13 +35,6 @@
+ 
+ #include <QtNetwork/QNetworkRequest>
+ 
+-#ifndef QT_NO_OPENGL
+-#include <QtOpenGL/QGLWidget>
+-#endif
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+-#include <QOpenGLWidget>
+-#endif
+-
+ #include <QDebug>
+ 
+ #include <cstdio>
+@@ -161,10 +154,6 @@
+     void showFindBar();
+     void find(int mode);
+ #endif
+-#ifndef QT_NO_OPENGL
+-    void toggleQGLWidgetViewport(bool enable);
+-    void toggleQOpenGLWidgetViewport(bool enable);
+-#endif
+     void toggleForcedAntialiasing(bool enable);
+ 
+     void changeViewportUpdateMode(int mode);
+--- src/Tools/QtTestBrowser/launcherwindow.cpp	2021-05-15 10:11:33.618702166 +0000
++++ src.mod/Tools/QtTestBrowser/launcherwindow.cpp	2021-05-15 10:14:30.829994642 +0000
+@@ -170,12 +170,7 @@
+     } else {
+         WebViewGraphicsBased* view = new WebViewGraphicsBased(splitter);
+         m_view = view;
+-        if (!m_windowOptions.useQOpenGLWidgetViewport)
+-            toggleQGLWidgetViewport(m_windowOptions.useQGLWidgetViewport);
+-#ifdef QT_OPENGL_LIB
+-        if (!m_windowOptions.useQGLWidgetViewport)
+-            toggleQOpenGLWidgetViewport(m_windowOptions.useQOpenGLWidgetViewport);
+-#endif
++
+         view->setPage(page());
+ 
+         connect(view, SIGNAL(currentFPSUpdated(int)), this, SLOT(updateFPS(int)));
+@@ -219,10 +214,6 @@
+ void LauncherWindow::applyPrefs()
+ {
+     QWebSettings* settings = page()->settings();
+-#ifndef QT_NO_OPENGL
+-    settings->setAttribute(QWebSettings::AcceleratedCompositingEnabled, m_windowOptions.useCompositing
+-        && (m_windowOptions.useQGLWidgetViewport || m_windowOptions.useQOpenGLWidgetViewport));
+-#endif
+     settings->setAttribute(QWebSettings::TiledBackingStoreEnabled, m_windowOptions.useTiledBackingStore);
+     settings->setAttribute(QWebSettings::FrameFlatteningEnabled, m_windowOptions.useFrameFlattening);
+     settings->setAttribute(QWebSettings::WebGLEnabled, m_windowOptions.useWebGL);
+@@ -437,21 +428,6 @@
+     toggleTiledBackingStore->setEnabled(isGraphicsBased());
+     toggleTiledBackingStore->connect(toggleGraphicsView, SIGNAL(toggled(bool)), SLOT(setEnabled(bool)));
+ 
+-#ifndef QT_NO_OPENGL
+-    QAction* toggleQGLWidgetViewport = graphicsViewMenu->addAction("Toggle use of QGLWidget Viewport", this, SLOT(toggleQGLWidgetViewport(bool)));
+-    toggleQGLWidgetViewport->setCheckable(true);
+-    toggleQGLWidgetViewport->setChecked(m_windowOptions.useQGLWidgetViewport);
+-    toggleQGLWidgetViewport->setEnabled(isGraphicsBased());
+-    toggleQGLWidgetViewport->connect(toggleGraphicsView, SIGNAL(toggled(bool)), SLOT(setEnabled(bool)));
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+-    QAction* toggleQOpenGLWidgetViewport = graphicsViewMenu->addAction("Toggle use of QOpenGLWidget Viewport", this, SLOT(toggleQOpenGLWidgetViewport(bool)));
+-    toggleQOpenGLWidgetViewport->setCheckable(true);
+-    toggleQOpenGLWidgetViewport->setChecked(m_windowOptions.useQOpenGLWidgetViewport);
+-    toggleQOpenGLWidgetViewport->setEnabled(isGraphicsBased());
+-    toggleQOpenGLWidgetViewport->connect(toggleGraphicsView, SIGNAL(toggled(bool)), SLOT(setEnabled(bool)));
+-#endif
+-#endif
+-
+     QMenu* viewportUpdateMenu = graphicsViewMenu->addMenu("Change Viewport Update Mode");
+     viewportUpdateMenu->setEnabled(isGraphicsBased());
+     viewportUpdateMenu->connect(toggleGraphicsView, SIGNAL(toggled(bool)), SLOT(setEnabled(bool)));
+@@ -848,13 +824,6 @@
+             label->setWindowTitle(QString("Screenshot - Saved at %1").arg(fileName));
+     }
+ #endif
+-
+-#ifndef QT_NO_OPENGL
+-    if (!m_windowOptions.useQOpenGLWidgetViewport)
+-        toggleQGLWidgetViewport(m_windowOptions.useQGLWidgetViewport);
+-    if (!m_windowOptions.useQGLWidgetViewport)
+-        toggleQOpenGLWidgetViewport(m_windowOptions.useQOpenGLWidgetViewport);
+-#endif
+ }
+ 
+ void LauncherWindow::setEditable(bool on)
+@@ -1062,36 +1031,6 @@
+     page()->settings()->setAttribute(QWebSettings::PluginsEnabled, !enable);
+ }
+ 
+-#ifndef QT_NO_OPENGL
+-void LauncherWindow::toggleQGLWidgetViewport(bool enable)
+-{
+-    if (!isGraphicsBased())
+-        return;
+-
+-    if (enable)
+-        m_windowOptions.useQOpenGLWidgetViewport = false;
+-    m_windowOptions.useQGLWidgetViewport = enable;
+-
+-    WebViewGraphicsBased* view = static_cast<WebViewGraphicsBased*>(m_view);
+-    view->setViewport(enable ? new QGLWidget() : 0);
+-}
+-
+-void LauncherWindow::toggleQOpenGLWidgetViewport(bool enable)
+-{
+-    if (!isGraphicsBased())
+-        return;
+-
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+-    if (enable)
+-        m_windowOptions.useQGLWidgetViewport = false;
+-    m_windowOptions.useQOpenGLWidgetViewport = enable;
+-
+-    WebViewGraphicsBased* view = static_cast<WebViewGraphicsBased*>(m_view);
+-    view->setViewport(enable ? new QOpenGLWidget() : 0);
+-#endif
+-}
+-#endif
+-
+ void LauncherWindow::toggleForcedAntialiasing(bool enable)
+ {
+     m_windowOptions.useForcedAntialiasing = enable;

--- a/packages/qt5-qtwebkit/webkit-bwo141288.patch
+++ b/packages/qt5-qtwebkit/webkit-bwo141288.patch
@@ -1,0 +1,71 @@
+From 7cc86ebe881f36bfef18d8eeee666d2a55eae892 Mon Sep 17 00:00:00 2001
+From: Guilherme Iscaro <iscaro@profusion.mobi>
+Date: Fri, 31 Mar 2017 10:31:49 -0300
+Subject: [PATCH] Fix build on ARMv6.
+
+The ARMv6 and older architures does not support the movw and movl
+instructions, thus causing a build break.
+This patch fix the problem by creating a new offlineasm instruction,
+which will use the ldr instruction to load a immediate into a register.
+
+https://bugs.webkit.org/show_bug.cgi?id=141288
+
+Reviewed by NOBODY (OOPS!).
+
+* llint/LowLevelInterpreter.asm:
+* offlineasm/arm.rb:
+* offlineasm/instructions.rb:
+---
+ Source/JavaScriptCore/llint/LowLevelInterpreter.asm | 8 +++++++-
+ Source/JavaScriptCore/offlineasm/arm.rb             | 2 ++
+ Source/JavaScriptCore/offlineasm/instructions.rb    | 3 ++-
+ 3 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+index ab3c0c8e771..6c32eef8852 100644
+--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
++++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+@@ -1167,7 +1167,13 @@ macro setEntryAddress(index, label)
+         move index, t4
+         storep t1, [a0, t4, 8]
+     elsif ARM or ARMv7 or ARMv7_TRADITIONAL
+-        mvlbl (label - _relativePCBase), t4
++        if ARM
++           ldrlbl t4, label
++           ldrlbl t3, _relativePCBase
++           subp t4, t3, t4
++        else
++           mvlbl (label - _relativePCBase), t4
++        end
+         addp t4, t1, t4
+         move index, t3
+         storep t4, [a0, t3, 4]
+diff --git a/Source/JavaScriptCore/offlineasm/arm.rb b/Source/JavaScriptCore/offlineasm/arm.rb
+index c8064a59196..a9c40c8995c 100644
+--- a/Source/JavaScriptCore/offlineasm/arm.rb
++++ b/Source/JavaScriptCore/offlineasm/arm.rb
+@@ -504,6 +504,8 @@ class Instruction
+         when "mvlbl"
+                 $asm.puts "movw #{operands[1].armOperand}, \#:lower16:#{operands[0].value}"
+                 $asm.puts "movt #{operands[1].armOperand}, \#:upper16:#{operands[0].value}"
++        when "ldrlbl"
++            $asm.puts "ldr #{operands[0].armOperand}, =#{operands[1].value}"
+         when "nop"
+             $asm.puts "nop"
+         when "bieq", "bpeq", "bbeq"
+diff --git a/Source/JavaScriptCore/offlineasm/instructions.rb b/Source/JavaScriptCore/offlineasm/instructions.rb
+index bbfce7193b3..8cc1cb961ce 100644
+--- a/Source/JavaScriptCore/offlineasm/instructions.rb
++++ b/Source/JavaScriptCore/offlineasm/instructions.rb
+@@ -261,7 +261,8 @@ X86_INSTRUCTIONS =
+ ARM_INSTRUCTIONS =
+     [
+      "clrbp",
+-     "mvlbl"
++     "mvlbl",
++     "ldrlbl"
+     ]
+ 
+ ARM64_INSTRUCTIONS =
+-- 
+2.12.1

--- a/packages/qt5-qtwebsockets/build.sh
+++ b/packages/qt5-qtwebsockets/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://www.qt.io/
+TERMUX_PKG_DESCRIPTION="Qt 5 WebSockets Library"
+TERMUX_PKG_LICENSE="LGPL-3.0"
+TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
+TERMUX_PKG_VERSION=5.12.10
+TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/${TERMUX_PKG_NAME#qt5-}-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=59127f8b10692fc17f54155ae53db8e19398284eab207c4f04438d368a6ee45c
+TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true
+
+termux_step_configure () {
+    "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
+        -spec "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-cross"
+}
+
+termux_step_post_make_install() {
+    #######################################################
+    ##
+    ##  Fixes & cleanup.
+    ##
+    #######################################################
+
+    ## Drop QMAKE_PRL_BUILD_DIR because reference the build dir.
+    sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' "${TERMUX_PREFIX}/lib/libQt5WebSockets.prl"
+
+    ## Remove *.la files.
+    find "${TERMUX_PREFIX}/lib" -iname \*.la -delete
+}
+


### PR DESCRIPTION
## Changes
 - Multimedia module has been fixed to use GStreamer properly (tested working with video and audio playback)
 - Qt Location, Qt Sensors are added as dependencies of Qt WebKit module
 - Qt WebSockets, Qt WebChannel are added (during an attempt to use WebKit 2)
 - [`otter-browser`](https://github.com/OtterBrowser/otter-browser/) is added 
 

## Known issues
 - Video playback is NOT working in `otter-browser` at the moment
 - QtWebKit is based on an old webkit codebase and has unpatched security vulnerabilities. Use it in restricted environment and do not transmit sensitive data