### PR TITLE
Build Qt with glib and build GTK+ platform theme plugin

### DIFF
--- a/packages/qt5-qtbase/build.sh
+++ b/packages/qt5-qtbase/build.sh
@@ -3,10 +3,12 @@ TERMUX_PKG_DESCRIPTION="A cross-platform application and UI framework"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION=5.12.10
-TERMUX_PKG_REVISION=7
+TERMUX_PKG_REVISION=8
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/5.12/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=8088f174e6d28e779516c083b6087b6a9e3c8322b4bc161fd1b54195e3c86940
-TERMUX_PKG_DEPENDS="dbus, double-conversion, harfbuzz, libandroid-shmem, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, openssl, pcre2, ttf-dejavu, freetype, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib"
+TERMUX_PKG_DEPENDS="dbus, double-conversion, harfbuzz, libandroid-shmem, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, openssl, pcre2, ttf-dejavu, freetype, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib, glib"
+# gtk3 dependency is a run-time dependency only for the gtk platformtheme subpackage
+TERMUX_PKG_BUILD_DEPENDS="gtk3"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STATICSPLIT=true
 
@@ -28,6 +30,7 @@ termux_step_pre_configure () {
 
     ## Create qmake.conf suitable for cross-compiling.
     sed \
+        -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
         -e "s|@TERMUX_CC@|${TERMUX_HOST_PLATFORM}-clang|" \
         -e "s|@TERMUX_CXX@|${TERMUX_HOST_PLATFORM}-clang++|" \
         -e "s|@TERMUX_AR@|${TERMUX_HOST_PLATFORM}-ar|" \
@@ -61,11 +64,26 @@ termux_step_configure () {
         -hostbindir "${TERMUX_PREFIX}/opt/qt/cross/bin" \
         -hostlibdir "${TERMUX_PREFIX}/opt/qt/cross/lib" \
         -I "${TERMUX_PREFIX}/include" \
+        -I "${TERMUX_PREFIX}/include/glib-2.0" \
+        -I "${TERMUX_PREFIX}/lib/glib-2.0/include" \
+        -I "${TERMUX_PREFIX}/include/gio-unix-2.0" \
+        -I "${TERMUX_PREFIX}/include/cairo" \
+        -I "${TERMUX_PREFIX}/include/pango-1.0" \
+        -I "${TERMUX_PREFIX}/include/fribidi" \
+        -I "${TERMUX_PREFIX}/include/harfbuzz" \
+        -I "${TERMUX_PREFIX}/include/atk-1.0" \
+        -I "${TERMUX_PREFIX}/include/pixman-1" \
+        -I "${TERMUX_PREFIX}/include/uuid" \
+        -I "${TERMUX_PREFIX}/include/libxml2" \
+        -I "${TERMUX_PREFIX}/include/freetype2" \
+        -I "${TERMUX_PREFIX}/include/gdk-pixbuf-2.0" \
+        -I "${TERMUX_PREFIX}/include/gtk-3.0" \
         -L "${TERMUX_PREFIX}/lib" \
         -nomake examples \
         -no-pch \
         -no-accessibility \
-        -no-glib \
+        -glib \
+        -gtk \
         -icu \
         -system-doubleconversion \
         -system-pcre \
@@ -184,9 +202,9 @@ termux_step_post_make_install() {
     find "${TERMUX_PREFIX}/opt/qt/cross/lib" -iname \*.la -delete
 
     ## Create qmake.conf suitable for compiling host tools (for other modules)
-    install -Dm644 \
-        "${TERMUX_PKG_BUILDER_DIR}/qmake.host.conf" \
-        "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qmake.conf"
+    sed \
+        -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+        "${TERMUX_PKG_BUILDER_DIR}/qmake.host.conf" > "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qmake.conf"
     install -Dm644 \
         "${TERMUX_PKG_BUILDER_DIR}/qplatformdefs.host.h" \
         "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qplatformdefs.h"

--- a/packages/qt5-qtbase/build.sh
+++ b/packages/qt5-qtbase/build.sh
@@ -202,12 +202,12 @@ termux_step_post_make_install() {
     find "${TERMUX_PREFIX}/opt/qt/cross/lib" -iname \*.la -delete
 
     ## Create qmake.conf suitable for compiling host tools (for other modules)
-    sed \
-        -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
-        "${TERMUX_PKG_BUILDER_DIR}/qmake.host.conf" > "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qmake.conf"
     install -Dm644 \
         "${TERMUX_PKG_BUILDER_DIR}/qplatformdefs.host.h" \
         "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qplatformdefs.h"
+    sed \
+        -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+        "${TERMUX_PKG_BUILDER_DIR}/qmake.host.conf" > "${TERMUX_PREFIX}/lib/qt/mkspecs/termux-host/qmake.conf"
 }
 
 termux_step_create_debscripts() {

--- a/packages/qt5-qtbase/glib_gtk_detection_without_pkgconfig.patch
+++ b/packages/qt5-qtbase/glib_gtk_detection_without_pkgconfig.patch
@@ -1,0 +1,24 @@
+--- src/src/corelib/configure.json	2020-09-21 13:16:21.000000000 +0000
++++ src.mod/src/corelib/configure.json	2021-05-18 13:05:04.670547308 +0000
+@@ -44,7 +44,8 @@
+             },
+             "headers": "glib.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "glib-2.0 gthread-2.0" }
++                { "type": "pkgConfig", "args": "glib-2.0 gthread-2.0" },
++                { "libs": "-lgthread-2.0 -lglib-2.0" }
+             ]
+         },
+         "posix_iconv": {
+--- src/src/widgets/configure.json	2020-09-21 13:16:21.000000000 +0000
++++ src.mod/src/widgets/configure.json	2021-05-18 13:07:19.325327327 +0000
+@@ -21,7 +21,8 @@
+         "gtk3": {
+             "label": "GTK+ >= 3.6",
+             "sources": [
+-                { "type": "pkgConfig", "args": "gtk+-3.0 >= 3.6" }
++                { "type": "pkgConfig", "args": "gtk+-3.0 >= 3.6" },
++                { "libs": "-lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0" }
+             ]
+         }
+     },

--- a/packages/qt5-qtbase/qmake.conf
+++ b/packages/qt5-qtbase/qmake.conf
@@ -8,6 +8,9 @@ include(../common/linux.conf)
 include(../common/gcc-base-unix.conf)
 include(../common/clang.conf)
 
+QMAKE_INCDIR           += @TERMUX_PREFIX@/include/glib-2.0
+QMAKE_INCDIR           += @TERMUX_PREFIX@/lib/glib-2.0/include
+
 QMAKE_CC                = @TERMUX_CC@
 QMAKE_CXX               = @TERMUX_CXX@
 QMAKE_LINK              = $${QMAKE_CXX}

--- a/packages/qt5-qtbase/qmake.host.conf
+++ b/packages/qt5-qtbase/qmake.host.conf
@@ -9,7 +9,8 @@ include(../common/linux.conf)
 include(../common/gcc-base-unix.conf)
 include(../common/g++-unix.conf)
 
-QMAKE_CFLAGS           += -I/data/data/com.termux/files/usr/include
-QMAKE_CXXFLAGS         += -I/data/data/com.termux/files/usr/include
+QMAKE_INCDIR           += @TERMUX_PREFIX@/include
+QMAKE_INCDIR           += @TERMUX_PREFIX@/include/glib-2.0
+QMAKE_INCDIR           += @TERMUX_PREFIX@/lib/glib-2.0/include
 
 load(qt_config)

--- a/packages/qt5-qtbase/qt5-qtbase-gtk-platformtheme.subpackage.sh
+++ b/packages/qt5-qtbase/qt5-qtbase-gtk-platformtheme.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="GTK+ 3 platform theme for Qt 5"
+TERMUX_SUBPKG_DEPENDS="qt5-qtbase, gtk3"
+TERMUX_SUBPKG_INCLUDE="
+libexec/qt/platformthemes/libqgtk3.so
+lib/cmake/Qt5Gui/Qt5Gui_QGtk3ThemePlugin.cmake
+"


### PR DESCRIPTION
The ugliness of the include directories is due to the Qt
build system in this version refuses to use pkg-config.

To use GTK+3 platform theme, install the new subpackage,

```bash
export QT_QPA_PLATFORMTHEME=gtk3
```

This should make Qt applications look more _native_ under GTK-based DE