### PR TITLE
Fix libmpg123 not found

### DIFF
--- a/packages/chocolate-doom/build.sh
+++ b/packages/chocolate-doom/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_VERSION=3.0.1
 TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://github.com/chocolate-doom/chocolate-doom/archive/refs/tags/chocolate-doom-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a54383beef6a52babc5b00d58fcf53a454f012ced7b1936ba359b13f1f10ac66
-TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net"
+TERMUX_PKG_DEPENDS="sdl2, sdl2-mixer, sdl2-net, mpg123"
 
 termux_step_pre_configure(){
     autoreconf -fi


### PR DESCRIPTION
This fix includes a fix of missing library of mpg123 for first time installation