### PR TITLE
Add packages: xorg-xwininfo, xorg-xprop

### DIFF
--- a/packages/xorg-xprop/build.sh
+++ b/packages/xorg-xprop/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://xorg.freedesktop.org/
+TERMUX_PKG_DESCRIPTION="Utility to print properties of X11 windows"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Rafael Kitover <rkitover@gmail.com>"
+TERMUX_PKG_VERSION=1.2.5
+TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/app/xprop-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=9b92ed0316bf2486121d8bac88bd1878f16b43bd335f18009b1f941f1eca93a1
+TERMUX_PKG_DEPENDS="libx11"
+TERMUX_PKG_BUILD_DEPENDS="xorg-util-macros"

--- a/packages/xorg-xwininfo/build.sh
+++ b/packages/xorg-xwininfo/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://xorg.freedesktop.org/
+TERMUX_PKG_DESCRIPTION="Utility to print information about X11 windows"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Rafael Kitover <rkitover@gmail.com>"
+TERMUX_PKG_VERSION=1.1.5
+TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/app/xwininfo-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=7a405441dfc476666c744f5fcd1bc8a75abf8b5b1d85db7b88b370982365080e
+TERMUX_PKG_DEPENDS="libx11, libiconv"
+TERMUX_PKG_BUILD_DEPENDS="xorg-util-macros"


### PR DESCRIPTION
These are both utilities from xorg, although both show information about windows they work differently, `xprop` is particularly useful because it prints `WM_CLASS`.