### PR TITLE
force linking libc++_shared for ClangTools, fixing #391

### DIFF
--- a/packages/qt-creator/build.sh
+++ b/packages/qt-creator/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Integrated Development Environment for Qt"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION=4.12.4
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL="https://github.com/qt-creator/qt-creator/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=2469a19ee230eb600467e614c23ed678b1b414adc16efdedcfc0404bf40d8015
 TERMUX_PKG_DEPENDS="qt5-qtbase, qt5-qtdeclarative, qt5-qtxmlpatterns, qt5-qttools, qt5-qtx11extras, qt5-qtsvg, llvm, clang"
@@ -31,6 +31,10 @@ termux_step_post_configure() {
     # clangbackend's Makefile lacks -lc++_shared to link against libc++ on x86_64
     sed -i 's|^LIBS          = $(SUBLIBS)|LIBS = $(SUBLIBS) -lc++_shared|' \
         ${TERMUX_PKG_SRCDIR}/src/tools/clangbackend/Makefile
+
+    # make sure clangtools link against libc++_shared on x86_64
+    sed -i 's|^LIBS          = $(SUBLIBS)|LIBS = $(SUBLIBS) -lc++_shared|' \
+        ${TERMUX_PKG_SRCDIR}/src/plugins/clangtools//Makefile
 
     # required by make install, otherwise it installs to '/'
     export INSTALL_ROOT="${TERMUX_PREFIX}"


### PR DESCRIPTION
Now the output of ` readelf --dynamic /data/data/com.termux/files/usr/lib/qtcreator/plugins/libClangTools.so` shows `libc++_shared.so` is the shared library needed.

```plain
 0x0000000000000001 (NEEDED)             Shared library: [libandroid-shmem.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc++_shared.so]
 0x0000000000000001 (NEEDED)             Shared library: [libDebugger.so]
 0x0000000000000001 (NEEDED)             Shared library: [libCppTools.so]
 0x0000000000000001 (NEEDED)             Shared library: [libCore.so]
 0x0000000000000001 (NEEDED)             Shared library: [libProjectExplorer.so]
 0x0000000000000001 (NEEDED)             Shared library: [libTextEditor.so]
 0x0000000000000001 (NEEDED)             Shared library: [libyaml-cpp.so.4]
 0x0000000000000001 (NEEDED)             Shared library: [libExtensionSystem.so.4]
 0x0000000000000001 (NEEDED)             Shared library: [libUtils.so.4]
 0x0000000000000001 (NEEDED)             Shared library: [libclang.so]
 0x0000000000000001 (NEEDED)             Shared library: [libQt5Widgets.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libQt5Gui.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libQt5Core.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so]
 0x000000000000000e (SONAME)             Library soname: [libClangTools.so]
```