### PR TITLE
add package : gtk-engines-xfce

### DIFF
--- a/packages/gtk-engines-xfce/build.sh
+++ b/packages/gtk-engines-xfce/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://www.xfce.org/
+TERMUX_PKG_DESCRIPTION="GTK 2/3 theme engine for Xfce"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="Yisus7u7 <jesuspixel5@gmail.com>"
+TERMUX_PKG_VERSION=3.2.0
+TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/g/gtk2-engines-xfce/gtk2-engines-xfce_${TERMUX_PKG_VERSION}.orig.tar.bz2
+TERMUX_PKG_SHA256=875c9c3bda96faf050a2224649cc42129ffb662c4de33add8c0fd1fb860b47ed
+TERMUX_PKG_DEPENDS="gtk2, gtk3, atk, libcairo, gdk-pixbuf, glib, pango"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-gtk2  --enable-gtk3"

--- a/packages/gtk-engines-xfce/build.sh
+++ b/packages/gtk-engines-xfce/build.sh
@@ -7,3 +7,4 @@ TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/g/gtk2-engines-xfce/gtk
 TERMUX_PKG_SHA256=875c9c3bda96faf050a2224649cc42129ffb662c4de33add8c0fd1fb860b47ed
 TERMUX_PKG_DEPENDS="gtk2, gtk3, atk, libcairo, gdk-pixbuf, glib, pango"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-gtk2  --enable-gtk3"
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
This package improves the quality of the appearance, and optimization of gtk in xfce4, can be added as a dependency of the package "xfce4"

Normally two separate packages are used "one for gtk2 and one for gtk3", but in this package both are included, it seems cleaner to me. 