### PR TITLE
add package: Parole media player

### DIFF
--- a/packages/parole/build.sh
+++ b/packages/parole/build.sh
@@ -6,5 +6,5 @@ TERMUX_PKG_VERSION=4.16.0
 TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/p/parole/parole_${TERMUX_PKG_VERSION}.orig.tar.bz2
 TERMUX_PKG_SHA256=0d305ad8ccd3974d6b632f74325b1b8a39304c905c6b405b70f52c4cfd55a7e7
 # gstreamer all plugins for all support in parole
-TERMUX_PKG_DEPENDS="gtk3, gstreamer, gst-plugins-base, gst-plugins-bad, gst-plugins-god, gst-plugins-ugly, atk, libcairo, dbus-glib, libnotify, pango, libxfce4util, libxfce4ui, xfconf, taglib"
+TERMUX_PKG_DEPENDS="gtk3, gstreamer, gst-plugins-base, gst-plugins-bad, gst-plugins-good, gst-plugins-ugly, atk, libcairo, dbus-glib, libnotify, pango, libxfce4util, libxfce4ui, xfconf, taglib"
 TERMUX_PKG_BUILD_IN_SRC=true

--- a/packages/parole/build.sh
+++ b/packages/parole/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=https://docs.xfce.org/apps/parole/start
+TERMUX_PKG_DESCRIPTION="Parole is a media player for the Xfce desktop environment, written using the GStreamer framework."
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Yisus7u7 <jesuspixel5@gmail.com>"
+TERMUX_PKG_VERSION=4.16.0
+TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/p/parole/parole_${TERMUX_PKG_VERSION}.orig.tar.bz2
+TERMUX_PKG_SHA256=0d305ad8ccd3974d6b632f74325b1b8a39304c905c6b405b70f52c4cfd55a7e7
+# gstreamer all plugins for all support in parole
+TERMUX_PKG_DEPENDS="gtk3, gstreamer, gst-plugins-base, gst-plugins-bad, gst-plugins-god, gst-plugins-ugly, atk, libcairo, dbus-glib, libnotify, pango, libxfce4util, libxfce4ui, xfconf, taglib"
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
![Screenshot_20211120-141036](https://user-images.githubusercontent.com/64093255/142738297-90e33c8c-dc70-4d64-97b4-50def9c4dc59.png)
![Screenshot_20211120-131602](https://user-images.githubusercontent.com/64093255/142738299-f9b4e84e-3854-4d26-badd-6f9e944dc4f7.png)

Parole is the official music player of XFCE, I compiled it and it works very well, the videos go fluid even in vnc, this is a great achievement, it can be replaced mpv-x at last 