### PR TITLE
tint2: update package

### DIFF
--- a/packages/tint2/build.sh
+++ b/packages/tint2/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=17.0.2
 TERMUX_PKG_SRCURL=https://gitlab.com/o9000/tint2/-/archive/${TERMUX_PKG_VERSION}/tint2-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=705a4505ab7a007e56d1c6dc2749ffb8eaabcc1d22f17ff2b2d29bdbeb0f28c5
+TERMUX_PKG_SHA256=f87f147e176d32f31f12fc1737f75f54c4c6f77961c6a2615ef9d64cb29ce24c
 TERMUX_PKG_DEPENDS="xorg-xrandr, libxinerama, libx11, xorgproto, libandroid-glob, libandroid-shmem, pango, libc++, libcairo, libcurl, libxcb, xcb-util-cursor, xcb-util-image, xcb-util-xrm, xcb-util-wm, pulseaudio, libxcomposite, libxdamage, gtk2, imlib2, libandroid-wordexp, librsvg, startup-notification, libcairo"
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/tint2/build.sh
+++ b/packages/tint2/build.sh
@@ -1,11 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://gitlab.com/o9000/tint2
 TERMUX_PKG_DESCRIPTION="Lightweight panel, Highly customizable"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_MAINTAINER="Laya Achmad"
-TERMUX_PKG_VERSION=16.2
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/o9000/tint2/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=a95c8a22d4cc117335b3157c7de48da91c8721fc97f86d0353c545eed2598ce8
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=17.0.2
+TERMUX_PKG_SRCURL=https://gitlab.com/o9000/tint2/-/archive/${TERMUX_PKG_VERSION}/tint2-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=705a4505ab7a007e56d1c6dc2749ffb8eaabcc1d22f17ff2b2d29bdbeb0f28c5
 TERMUX_PKG_DEPENDS="xorg-xrandr, libxinerama, libx11, xorgproto, libandroid-glob, libandroid-shmem, pango, libc++, libcairo, libcurl, libxcb, xcb-util-cursor, xcb-util-image, xcb-util-xrm, xcb-util-wm, pulseaudio, libxcomposite, libxdamage, gtk2, imlib2, libandroid-wordexp, librsvg, startup-notification, libcairo"
 TERMUX_PKG_BUILD_IN_SRC=true
 


### PR DESCRIPTION
- The github one is fairly outdated so moving the source code URL to gitlab which contains the new version
- Changing maintainership as github account does not exists anymore